### PR TITLE
chore: remove deprecated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Removed deprecated functions `single` and `wrap_result`
+
 ## v0.2.1
 
 - Updated unit tests

--- a/src/valguard.gleam
+++ b/src/valguard.gleam
@@ -61,27 +61,6 @@ pub fn prepare_with(
   }
 }
 
-/// Wrap list of errors from a Validation Result in a custom type.
-@deprecated("Function will be removed in next release. If needed, you can implement it yourself.")
-pub fn wrap_result(
-  result: Result(Nil, List(ValidationError)),
-  custom_type,
-) -> Result(Nil, custom_type) {
-  result.map_error(result, fn(errors) { custom_type(errors) })
-}
-
-/// Validates a single validation function
-@deprecated("Use function `with` instead")
-pub fn single(
-  key: String,
-  validation_result: Result(Nil, String),
-) -> Result(Nil, ValidationError) {
-  case validation_result {
-    Ok(Nil) -> Ok(Nil)
-    Error(value) -> Error(ValidationError(key:, value:))
-  }
-}
-
 /// Validates a list of requirements lazily.
 ///
 /// Takes a key and list of validation functions.

--- a/test/valguard_test.gleam
+++ b/test/valguard_test.gleam
@@ -83,18 +83,6 @@ pub fn prepare_with_returns_custom_error_with_validation_list_inside_test() {
   assert actual == expected
 }
 
-pub fn single_returns_ok_test() {
-  let actual = valguard.single("test", Ok(Nil))
-  let expected = Ok(Nil)
-  assert actual == expected
-}
-
-pub fn single_returns_validation_error_test() {
-  let actual = valguard.single("test", Error("test"))
-  let expected = Error(ValidationError(key: "test", value: "test"))
-  assert actual == expected
-}
-
 pub fn list_returns_ok_when_functions_return_ok_test() {
   let validations = [
     fn() { Ok(Nil) },


### PR DESCRIPTION
Removes deprecated functions `single` and `wrap_result`.